### PR TITLE
Always export POD_NAME as env variable

### DIFF
--- a/kubejobs/jobs.py
+++ b/kubejobs/jobs.py
@@ -1,5 +1,3 @@
-import datetime
-import enum
 import grp
 import json
 import logging


### PR DESCRIPTION
I was looking to access the pod name from within the pod. The way to do this is to add:

```python
{
                "name": "POD_NAME",
                "valueFrom": {"fieldRef": {"fieldPath": "metadata.name"}},
}
```

to the environnment variables.

Also linted with ruff / removed unused imports. Can remove these lint changes if you want.