### PR TITLE
Add NFS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,23 @@ print(job.generate_yaml())
 job.run()
 ```
 
+#### NFS partition
+
+You can mount an NFS partition to the Kubernetes Job by specifying the NFS server address, path, and mount options.
+
+```python
+from kubejobs.jobs import KubernetesJob
+
+job = KubernetesJob(
+    ...
+    volume_mounts={
+        "nfs": {"mountPath": "/nfs", "server": "10.24.1.255", "path": "/"}
+    },
+)
+```
+Note that both `server` and `path` are required fields for the NFS volume mount.
+
+
 ### create_jobs_for_experiments
 
 The create_jobs_for_experiments function allows you to create and run a series of Kubernetes Jobs for a list of commands. This can be helpful for running multiple experiments or tasks with different parameters in parallel.

--- a/kubejobs/jobs.py
+++ b/kubejobs/jobs.py
@@ -370,6 +370,11 @@ class KubernetesJob:
                 elif "emptyDir" in mount_data:
                     volume["emptyDir"] = {}
                 # Add more volume types here if needed
+                if "server" in mount_data:
+                    volume["nfs"] = {
+                        "server": mount_data["server"],
+                        "path": mount_data["path"],
+                    }
 
                 job["spec"]["template"]["spec"]["volumes"].append(volume)
 


### PR DESCRIPTION
Given we now have an NFS partition. This allows us to use it by passing the following:

```python
    job = KubernetesJob(
       ...
        volume_mounts={
            "nfs": {"mountPath": "/nfs", "server": "10.24.1.255", "path": "/"}
        },
    )
```

Then from within the pod we can access it at `/nfs/...`

