### PR TITLE
change default backoff policy to 0

### DIFF
--- a/kubejobs/jobs.py
+++ b/kubejobs/jobs.py
@@ -109,7 +109,7 @@ class KubernetesJob:
         gpu_type: Optional[str] = None,
         gpu_product: Optional[str] = None,
         gpu_limit: Optional[int] = None,
-        backoff_limit: int = 4,
+        backoff_limit: int = 0,
         restart_policy: str = "Never",
         shm_size: Optional[str] = None,
         secret_env_vars: Optional[dict] = None,


### PR DESCRIPTION

Problem with callback > 0 is that your job will always recreate pods if they error, and timeouts are counted as timeouts.. This means that interactive sessions that expire after the time limit, will just keep respawning. 

Some retrying can be useful sometimes, but in the way most jobs are currently set up, it would be better to just force users to resubmit a job rather than automatically give them another pod. 

Default should therefore probably be 0 for sanity.