### PR TITLE
ValidatingAdmissionPolicy 'generate-name-validating-admission-policy'…

### DIFF
--- a/kubejobs/jobs.py
+++ b/kubejobs/jobs.py
@@ -313,7 +313,8 @@ class KubernetesJob:
             "apiVersion": "batch/v1",
             "kind": "Job",
             "metadata": {
-                "name": self.name,
+                # "name": self.name,
+                "generateName": self.name + "-",
                 "labels": self.labels,  # Add labels here
                 "annotations": self.annotations,  # Add metadata here
             },


### PR DESCRIPTION
… with binding 'generate-name-validating-admission-policy-binding' denied request: generateName should be used for naming purposes.

This should fix it