### PR TITLE
fixes "cannot use generate name with apply"

### DIFF
--- a/kubejobs/jobs.py
+++ b/kubejobs/jobs.py
@@ -396,8 +396,11 @@ class KubernetesJob:
         with open("temp_job.yaml", "w") as temp_file:
             temp_file.write(job_yaml)
 
-        # Run the kubectl command with --validate=False
-        cmd = ["kubectl", "apply", "-f", "temp_job.yaml"]
+        # Run the kubectl command -- if generateName is being used, use kubectl create instead of apply
+        if "generateName" in job_yaml.get("metadata", {}):
+            cmd = ["kubectl", "create", "-f", "temp_job.yaml"]
+        else:
+            cmd = ["kubectl", "apply", "-f", "temp_job.yaml"]
 
         try:
             result = subprocess.run(

--- a/kubejobs/jobs.py
+++ b/kubejobs/jobs.py
@@ -396,8 +396,10 @@ class KubernetesJob:
         with open("temp_job.yaml", "w") as temp_file:
             temp_file.write(job_yaml)
 
+        job_dict = yaml.safe_load(job_yaml)
+
         # Run the kubectl command -- if generateName is being used, use kubectl create instead of apply
-        if "generateName" in job_yaml.get("metadata", {}):
+        if "generateName" in job_dict.get("metadata", {}):
             cmd = ["kubectl", "create", "-f", "temp_job.yaml"]
         else:
             cmd = ["kubectl", "apply", "-f", "temp_job.yaml"]

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 setup(
     name="kubejobs",
-    version="0.4.7",
+    version="0.4.8",
     description="A Python library for creating and running Kubernetes Jobs",
     long_description=long_description,
     long_description_content_type="text/markdown",  # This is important!


### PR DESCRIPTION
This issue came up:

```
[04/12/25 15:04:32] INFO     Command 'kubectl apply -f temp_job.yaml' failed with return code 1.                                                                                                                                                                                       jobs.py:414
                    INFO     Stdout:                                                                                                                                                                                                                                                   jobs.py:417
                                                                                                                                                                                                                                                                                                  
                    INFO     Stderr:                                                                                                                                                                                                                                                   jobs.py:418
                             error: from sft-coding-: cannot use generate name with apply 
```

This should fix it